### PR TITLE
Fix input deduplication e.g. two entries for one gene

### DIFF
--- a/safe_io.py
+++ b/safe_io.py
@@ -252,7 +252,7 @@ def calculate_edge_lengths(G, verbose=True):
     return G
 
 
-def load_attributes(attribute_file='', node_label_order=[], fill_value=np.nan, verbose=True):
+def load_attributes(attribute_file='', node_label_order=None, fill_value=np.nan, verbose=True):
 
     node2attribute = pd.DataFrame()
     attributes = pd.DataFrame()
@@ -305,7 +305,7 @@ def load_attributes(attribute_file='', node_label_order=[], fill_value=np.nan, v
     node_label_mapped = [x for x in node_label_in_file if x in node_label_order]
 
     # Averaging out duplicate rows (with notification)
-    if len(node_label_mapped) != len(set(node_label_mapped)):
+    if len(node_label_in_file) != len(set(node_label_in_file)):
         print('\nDuplicate row labels detected. Their values will be averaged.')
         node2attribute = node2attribute.groupby(node2attribute.index, axis=0).mean()
 


### PR DESCRIPTION
Would error out if user input duplicate rows that were not in the network

Error: `ValueError: cannot reindex from a duplicate axis`
On line: `node2attribute = node2attribute.reindex(index=node_label_order, fill_value=fill_value)`

Example input from AFT1 Yeast TF data from IDEA, modified to include duplicate entries:

ORF     Value
YMR056C -0.792311525
YMR056C -0.019015263
YMR056C -0.83412795
YMR056C -0.471975731
YNR016C -0.21730749
YBL015W -0.915305609
YLR304C -1.591613527
YJL200C -1.624091036
YLR153C -0.736739858
etc.

Example of input where only YBL015W and YLR153C are in the network itself
YNR016C, YLR304C, and YJL200C are successfully ignored, but duplicate YMR056C causes issues:
We check for duplicates via `if len(node_label_mapped) != len(set(node_label_mapped)):` to determine whether we should average values
but this only checks the mapped rows/nodes. Meanwhile, we try to reindex the whole array, including nodes that don't exist in the network

So if we *only* have duplicates in nodes that don't exist in the network, like YMR056C, they will not be caught by the old check (if there is at least one duplicate that exists in the network, the old check will catch it).
To fix this, I changed the check to `if len(node_label_in_file) != len(set(node_label_in_file)):`

Finally, I also noticed that the  check `if not node_label_order:`, although working as intended
(the default `node_label_order` parameter `[]` will be evaluated as `False`), I changed the default parameter to `None` to make this more clear.