### PR TITLE
using pickle instead of nx to load network.

### DIFF
--- a/safepy/safe_io.py
+++ b/safepy/safe_io.py
@@ -4,6 +4,7 @@ import re
 import os
 from pathlib import Path
 import logging
+import pickle
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -124,7 +125,8 @@ def load_network_from_txt(filename, layout='spring_embedded', node_key_attribute
 def load_network_from_gpickle(filename, verbose=True):
 
     filename = re.sub('~', expanduser('~'), filename)
-    G = nx.read_gpickle(filename)
+    with open(filename, 'rb') as f:
+        G = pickle.load(f)
 
     return G
 


### PR DESCRIPTION
I have networkx 3.2.1 installed.

Running `load_network()` gives the following error:

`AttributeError: module 'networkx' has no attribute 'read_gpickle'`

[Looking this up](https://networkx.org/documentation/stable/release/migration_guide_from_2.x_to_3.0.html#deprecated-code), it appears that `read_gpickle` and `write_gpickle` are no longer used in NetworkX 3.0. Pickle can handle this directly. So I made the changes recommended on the website.